### PR TITLE
[NO ticket] adjusting test flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "cross-env NODE_ENV=test ENV=test npm run test:all",
     "test:integration": "cross-env NODE_ENV=test ENV=test npm run test:_integration",
     "test:integration:single": "cross-env NODE_ENV=test ENV=test npm run test:prepare:integration && npm run mocha",
-    "test:unit": "cross-env NODE_ENV=test ENV=test npm run mocha \"test/**/*.test.ts\" --exclude \"test/**/*.integration.test.ts\" ",
+    "test:unit": "cross-env NODE_ENV=test ENV=test npm run mocha \"test/**/!(*integration).test.ts\"",
     "test:unit:single": "cross-env NODE_ENV=test ENV=test npm run mocha",
     "mocha": "cross-env ENV=test mocha --unhandled-rejections=strict",
     "eslint": "eslint src --fix",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist",
     "db:test:create": "docker-compose -p gameshq-api-test-project -f 'docker-compose-test.yml' up -d",
     "db:test:clear": "docker-compose -p gameshq-api-test-project -f 'docker-compose-test.yml' down",
-    "test:all": "concurrently --kill-others-on-fail --names *typescript,*****eslint,*tests:unit,integration --prefix-colors blue.inverse,blue,yellow,green 'npm run tsc' 'npm run eslint --quiet' 'npm run test:unit' 'npm run test:integration'",
+    "test:all": "concurrently --kill-others-on-fail --names *typescript,*****eslint,*tests:unit,integration --prefix-colors blue.inverse,blue,yellow,green 'npm run tsc' 'npm run eslint' 'npm run test:unit' 'npm run test:integration'",
     "test:prepare:integration": "npm run db:test:create &&  cross-env NODE_ENV=test ENV=test npm run prepare-db",
     "test:_integration": "npm run test:prepare:integration && npm run mocha \"test/**/*.integration.test.ts\"",
     "prepare": "husky install"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,11 @@
+import dotenv from 'dotenv';
+
 export { prettifyConfig } from './sqlPrettifyConfig';
 import { version } from '../../package.json';
 
+if (getConfig('NODE_ENV') !== 'production') {
+  dotenv.config({ path: '.env.dev' });
+}
 interface NameToType {
   // PROCESS
   ENV: 'production' | 'staging' | 'development' | 'test';

--- a/src/games/arena/actions/index.ts
+++ b/src/games/arena/actions/index.ts
@@ -12,7 +12,7 @@ import type {
   SlackBlockKitSelectMenuElement,
 } from '../../model/SlackBlockKit';
 import type { SlackBlockKitPayload } from '../../model/SlackBlockKitPayload';
-import { ZoneData } from '../../model/SlackDialogObject';
+import type { ZoneData } from '../../model/SlackDialogObject';
 import { extractSecondaryAction, getEphemeralText, getGameError, slackRequest } from '../../utils';
 import { ARENA_ACTIONS, ARENA_SECONDARY_ACTIONS, ARENA_SLACK_COMMANDS } from '../consts';
 import { ArenaRepository } from '../repositories/arena/arena';
@@ -114,18 +114,20 @@ export const handleViewSubmissionAction = async (payload: SlackBlockKitPayload) 
   }
 
   switch (callback_id) {
-    case ARENA_SECONDARY_ACTIONS.CREATE_OR_UPDATE_ZONE_DATA:
-      zoneRepository
-        .createOrUpdateZoneForm(userRequesting, values as ZoneData)
-        .then(async (response) => {
-          if (response?.type === 'error') {
-            await arenaNotifyEphemeral(
-              response.text ?? 'Something went wrong',
-              userRequesting.slackId!,
-              userRequesting.slackId!
-            );
-          }
-        });
+    case ARENA_SECONDARY_ACTIONS.CREATE_OR_UPDATE_ZONE_DATA: {
+      const response = await zoneRepository.createOrUpdateZoneForm(
+        userRequesting,
+        values as ZoneData
+      );
+
+      if (response?.type === 'error') {
+        await arenaNotifyEphemeral(
+          response.text ?? 'Something went wrong',
+          userRequesting.slackId!,
+          userRequesting.slackId!
+        );
+      }
+    }
   }
   return {};
 };
@@ -242,20 +244,22 @@ const handleConfigAction = async (
   switch (actionParsed) {
     case ARENA_SECONDARY_ACTIONS.UPDATE_ZONE:
       return ZoneRepository.openZoneModal(triggerId, selectedId);
-    case ARENA_SECONDARY_ACTIONS.DELETE_ZONE:
+    case ARENA_SECONDARY_ACTIONS.DELETE_ZONE: {
       if (!selectedId) {
         return getGameError(actionReply.needToSelectZoneToDelete);
       }
-      zoneRepository.deleteZone(userRequesting, selectedId).then(async (response) => {
-        if (response?.type === 'error') {
-          await arenaNotifyEphemeral(
-            response.text ?? 'Something went wrong',
-            userRequesting.slackId!,
-            userRequesting.slackId!
-          );
-        }
-      });
+
+      const response = await zoneRepository.deleteZone(userRequesting, selectedId);
+
+      if (response?.type === 'error') {
+        await arenaNotifyEphemeral(
+          response.text ?? 'Something went wrong',
+          userRequesting.slackId!,
+          userRequesting.slackId!
+        );
+      }
       break;
+    }
     default:
       break;
   }

--- a/src/games/arena/generators/gameplay.ts
+++ b/src/games/arena/generators/gameplay.ts
@@ -1,8 +1,8 @@
-import { ArenaPlayer, ArenaZone } from '../../../models';
+import type { ArenaPlayer, ArenaZone } from '../../../models';
 import { BOSS_HOUSE_EMOJI } from '../../consts/emojis';
 import { ZERO } from '../../consts/global';
 import { basicHealthDisplayInParentheses, generateTeamEmoji } from '../../helpers';
-import { SlackBlockKitLayoutElement } from '../../model/SlackBlockKit';
+import type { SlackBlockKitLayoutElement } from '../../model/SlackBlockKit';
 import { generateEndGameConfirmationBlockKit } from '../../utils/generators/games';
 import {
   blockKitAction,

--- a/src/games/arena/generators/weapons.ts
+++ b/src/games/arena/generators/weapons.ts
@@ -1,6 +1,6 @@
-import { Item } from '../../../models';
+import type { Item } from '../../../models';
 import { generateRarityColorEmoji } from '../../helpers';
-import {
+import type {
   SlackBlockKitCompositionOption,
   SlackBlockKitLayoutElement,
 } from '../../model/SlackBlockKit';

--- a/src/games/arena/generators/zones.ts
+++ b/src/games/arena/generators/zones.ts
@@ -6,7 +6,7 @@ import type {
   SlackBlockKitLayoutElement,
   SlackBlockKitSectionLayout,
 } from '../../model/SlackBlockKit';
-import { SlackDialog } from '../../model/SlackDialogObject';
+import type { SlackDialog } from '../../model/SlackDialogObject';
 import {
   blockKitAction,
   blockKitButton,

--- a/src/games/arena/repositories/arena/actions/admin/add-players.ts
+++ b/src/games/arena/repositories/arena/actions/admin/add-players.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
-import { User } from '../../../../../../models';
+
+import type { User } from '../../../../../../models';
 import { findActiveArenaGame } from '../../../../../../models/ArenaGame';
 import {
   addArenaPlayers,

--- a/src/games/arena/repositories/arena/actions/admin/list-players.ts
+++ b/src/games/arena/repositories/arena/actions/admin/list-players.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findActiveArenaGame } from '../../../../../../models/ArenaGame';
 import {
   findLivingPlayersByGame,

--- a/src/games/arena/repositories/arena/actions/admin/make-all-visible.ts
+++ b/src/games/arena/repositories/arena/actions/admin/make-all-visible.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { setAllPlayerVisibility } from '../../../../../../models/ArenaPlayer';
 import { findActiveRound } from '../../../../../../models/ArenaRound';
 import { removeActionFromRound } from '../../../../../../models/ArenaRoundAction';

--- a/src/games/arena/repositories/arena/actions/admin/performance.ts
+++ b/src/games/arena/repositories/arena/actions/admin/performance.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findActiveArenaGame, findLastActiveArenaGame } from '../../../../../../models/ArenaGame';
 import {
   findPlayersByGame,

--- a/src/games/arena/repositories/arena/actions/player/actions-menu.ts
+++ b/src/games/arena/repositories/arena/actions/player/actions-menu.ts
@@ -1,12 +1,10 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findSinglePlayerPerformance } from '../../../../../../models/ArenaPlayerPerformance';
-import { GameResponse, getGameError, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameError, getGameResponse } from '../../../../../utils';
 import { generateArenaActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function actionsMenu(userRequesting: User) {

--- a/src/games/arena/repositories/arena/actions/player/change-location.ts
+++ b/src/games/arena/repositories/arena/actions/player/change-location.ts
@@ -1,18 +1,16 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findSinglePlayerPerformance } from '../../../../../../models/ArenaPlayerPerformance';
 import {
   findPlayerRoundAction,
   setPlayerRoundAction,
 } from '../../../../../../models/ArenaRoundAction';
 import { findActiveArenaZones, findArenaZoneById } from '../../../../../../models/ArenaZone';
-import { GameResponse, getGameError, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameError, getGameResponse } from '../../../../../utils';
 import { ARENA_ACTIONS } from '../../../../consts';
 import { generateArenaActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function changeLocation(userRequesting: User, arenaZoneId: number) {

--- a/src/games/arena/repositories/arena/actions/player/cheer.ts
+++ b/src/games/arena/repositories/arena/actions/player/cheer.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import {
   findPlayerById,
   findPlayerByUser,
@@ -10,17 +10,15 @@ import {
   setPlayerRoundAction,
 } from '../../../../../../models/ArenaRoundAction';
 import { findActiveArenaZones } from '../../../../../../models/ArenaZone';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { ARENA_ACTIONS } from '../../../../consts';
 import {
   generateArenaActionsBlockKit,
   generateArenaTargetPickerBlock,
 } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function cheer(userRequesting: User) {

--- a/src/games/arena/repositories/arena/actions/player/hide.ts
+++ b/src/games/arena/repositories/arena/actions/player/hide.ts
@@ -1,15 +1,13 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findSinglePlayerPerformance } from '../../../../../../models/ArenaPlayerPerformance';
 import { setPlayerRoundAction } from '../../../../../../models/ArenaRoundAction';
 import { findActiveArenaZones } from '../../../../../../models/ArenaZone';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { ARENA_ACTIONS } from '../../../../consts';
 import { generateArenaActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function hide(userRequesting: User) {

--- a/src/games/arena/repositories/arena/actions/player/revive.ts
+++ b/src/games/arena/repositories/arena/actions/player/revive.ts
@@ -1,21 +1,19 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findPlayerByUser, findPlayersByGame } from '../../../../../../models/ArenaPlayer';
 import { findSinglePlayerPerformance } from '../../../../../../models/ArenaPlayerPerformance';
 import { setPlayerRoundAction } from '../../../../../../models/ArenaRoundAction';
 import { findActiveArenaZones } from '../../../../../../models/ArenaZone';
 import { findHealthkitByName } from '../../../../../../models/ItemHealthKit';
 import { ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { ARENA_ACTIONS, ARENA_HEALTHKITS, MAX_PLAYER_HEALTH } from '../../../../consts';
 import {
   generateArenaActionsBlockKit,
   generateArenaTargetPickerBlock,
 } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function reviveSelf(userRequesting: User) {

--- a/src/games/arena/repositories/arena/actions/player/search.ts
+++ b/src/games/arena/repositories/arena/actions/player/search.ts
@@ -1,15 +1,13 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findSinglePlayerPerformance } from '../../../../../../models/ArenaPlayerPerformance';
 import { setPlayerRoundAction } from '../../../../../../models/ArenaRoundAction';
 import { findActiveArenaZones } from '../../../../../../models/ArenaZone';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { ARENA_ACTIONS } from '../../../../consts';
 import { generateArenaActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  PlayerActionsDeadOrAlive,
-  playerActionsParams,
-  withArenaTransaction,
-} from '../../../../utils';
+import type { PlayerActionsDeadOrAlive } from '../../../../utils';
+import { playerActionsParams, withArenaTransaction } from '../../../../utils';
 import { arenaCommandReply } from '../../replies';
 
 export async function searchForWeapons(userRequesting: User) {

--- a/src/games/arena/repositories/arena/arena.ts
+++ b/src/games/arena/repositories/arena/arena.ts
@@ -1,5 +1,6 @@
 import type { User } from '../../../../models';
 import type { GameResponse } from '../../../utils';
+
 import {
   addBossOrGuestCommand,
   addPlayerCommand,
@@ -23,14 +24,13 @@ import {
   selectWeaponForEveryone,
   startNarrowWeaponsQuestion,
 } from './actions/admin/weapons';
+import { actionsMenu, status } from './actions/player/actions-menu';
 import { bossChangeLocation, changeLocation } from './actions/player/change-location';
 import { cheer, completeCheer, repeatLastCheer } from './actions/player/cheer';
 import { hide } from './actions/player/hide';
 import { chooseTarget, chooseWeapon, hunt } from './actions/player/hunt';
-import { actionsMenu, status } from './actions/player/actions-menu';
 import { completeRevive, reviveOther, reviveSelf } from './actions/player/revive';
 import { searchForArmors, searchForHealth, searchForWeapons } from './actions/player/search';
-
 import type { ArenaEngine } from './engine';
 
 interface ArenaRepositoryMethods {

--- a/src/games/arena/repositories/arena/engine/cheerSystem.ts
+++ b/src/games/arena/repositories/arena/engine/cheerSystem.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from 'sequelize';
-import { ArenaPlayer } from '../../../../../models';
+
+import type { ArenaPlayer } from '../../../../../models';
 import { Ability } from '../../../../classes/GameAbilities';
 import { ARENA_PERK } from '../../../consts';
 

--- a/src/games/arena/repositories/arena/engine/evaluateHunt.ts
+++ b/src/games/arena/repositories/arena/engine/evaluateHunt.ts
@@ -1,6 +1,7 @@
 import { random } from 'lodash';
 import type { Transaction } from 'sequelize';
-import { ArenaPlayer } from '../../../../../models';
+
+import type { ArenaPlayer } from '../../../../../models';
 import { findPlayerById } from '../../../../../models/ArenaPlayer';
 import {
   findFirstBlood,
@@ -20,6 +21,7 @@ import {
   MAX_PLAYER_HEALTH,
 } from '../../../consts';
 import { publishArenaMessage } from '../../../utils';
+
 import { aggressiveLoot } from './evaluateHuntHelpers/aggressiveLoot';
 import { huntablePlayersFilter } from './evaluateHuntHelpers/huntablePlayersFilter';
 import { targetsPicker } from './evaluateHuntHelpers/targetsPicker';

--- a/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/aggressiveLoot.ts
+++ b/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/aggressiveLoot.ts
@@ -1,14 +1,15 @@
-import { Transaction } from 'sequelize/types';
-import { ArenaPlayer } from '../../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { ArenaPlayer } from '../../../../../../models';
 import {
   addAmmoToItemInInventory,
   getPlayerItemCount,
 } from '../../../../../../models/ArenaItemInventory';
 import { findHealthkitByName } from '../../../../../../models/ItemHealthKit';
 import { ZERO } from '../../../../../consts/global';
+import { rarityWeight } from '../../../../../utils/rollRarity';
 import { ARENA_HEALTHKITS, MAX_PLAYER_HEALTH } from '../../../../consts';
 import { publishArenaMessage } from '../../../../utils';
-import { rarityWeight } from '../../../../../utils/rollRarity';
 import { arenaEngineReply } from '../replies';
 
 export async function aggressiveLoot(

--- a/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/huntablePlayersFilter.ts
+++ b/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/huntablePlayersFilter.ts
@@ -1,4 +1,4 @@
-import { ArenaPlayer } from '../../../../../../models';
+import type { ArenaPlayer } from '../../../../../../models';
 
 interface HuntablePlayersParams {
   huntablePlayers: ArenaPlayer[];

--- a/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/targetsPicker.ts
+++ b/src/games/arena/repositories/arena/engine/evaluateHuntHelpers/targetsPicker.ts
@@ -1,5 +1,6 @@
 import { get, sampleSize } from 'lodash';
-import { ArenaPlayer, Item } from '../../../../../../models';
+
+import type { ArenaPlayer, Item } from '../../../../../../models';
 import { TRAIT } from '../../../../../consts/global';
 
 export function targetsPicker(

--- a/src/games/arena/repositories/arena/engine/processChangeLocation.ts
+++ b/src/games/arena/repositories/arena/engine/processChangeLocation.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from 'sequelize';
-import { ArenaRoundAction } from '../../../../../models';
+
+import type { ArenaRoundAction } from '../../../../../models';
 import { findArenaZoneById } from '../../../../../models/ArenaZone';
 
 export async function processChangeLocation(actions: ArenaRoundAction[], transaction: Transaction) {

--- a/src/games/arena/repositories/arena/engine/processCheer.ts
+++ b/src/games/arena/repositories/arena/engine/processCheer.ts
@@ -1,9 +1,11 @@
 import type { Transaction } from 'sequelize';
-import { ArenaRound, ArenaRoundAction } from '../../../../../models';
+
+import type { ArenaRound, ArenaRoundAction } from '../../../../../models';
 import { findPlayerById } from '../../../../../models/ArenaPlayer';
 import { setPlayerPerformanceAction } from '../../../../../models/ArenaPlayerPerformance';
 import { ARENA_PLAYER_PERFORMANCE } from '../../../consts';
 import { publishArenaMessage } from '../../../utils';
+
 import { cheerAwards } from './cheerSystem';
 import { arenaEngineReply } from './replies';
 

--- a/src/games/arena/repositories/arena/engine/processHealOrRevive.ts
+++ b/src/games/arena/repositories/arena/engine/processHealOrRevive.ts
@@ -1,11 +1,13 @@
-import { Transaction } from 'sequelize/types';
-import { ArenaRound, ArenaRoundAction } from '../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { ArenaRound, ArenaRoundAction } from '../../../../../models';
 import { findPlayerById } from '../../../../../models/ArenaPlayer';
 import { setPlayerPerformanceAction } from '../../../../../models/ArenaPlayerPerformance';
 import { findHealthkitByName } from '../../../../../models/ItemHealthKit';
 import { ZERO } from '../../../../consts/global';
 import { ARENA_HEALTHKITS, ARENA_PLAYER_PERFORMANCE, MAX_PLAYER_HEALTH } from '../../../consts';
 import { publishArenaMessage } from '../../../utils';
+
 import { arenaEngineReply } from './replies';
 
 export async function processHealOrRevive(

--- a/src/games/arena/repositories/arena/engine/processHide.ts
+++ b/src/games/arena/repositories/arena/engine/processHide.ts
@@ -1,6 +1,8 @@
 import type { Transaction } from 'sequelize';
-import { ArenaRoundAction } from '../../../../../models';
+
+import type { ArenaRoundAction } from '../../../../../models';
 import { publishArenaMessage } from '../../../utils';
+
 import { arenaEngineReply } from './replies';
 
 export async function processHide(actions: ArenaRoundAction[], transaction: Transaction) {

--- a/src/games/arena/repositories/arena/engine/processRingSystem.ts
+++ b/src/games/arena/repositories/arena/engine/processRingSystem.ts
@@ -1,7 +1,9 @@
 import type { Transaction } from 'sequelize';
-import { ArenaRoundAction } from '../../../../../models';
+
+import type { ArenaRoundAction } from '../../../../../models';
 import { ARENA_ACTIONS, RING_SYSTEM_BASE_DAMAGE } from '../../../consts';
 import { publishArenaMessage } from '../../../utils';
+
 import { arenaEngineReply } from './replies';
 
 export async function processRingSystemPenalty(

--- a/src/games/arena/repositories/arena/engine/processSearch.ts
+++ b/src/games/arena/repositories/arena/engine/processSearch.ts
@@ -1,11 +1,18 @@
 import type { Transaction } from 'sequelize';
-import { ArenaRound, ArenaRoundAction } from '../../../../../models';
+
+import type { ArenaRound, ArenaRoundAction } from '../../../../../models';
 import { setPlayerPerformanceAction } from '../../../../../models/ArenaPlayerPerformance';
 import { listActiveArmorsByGameType } from '../../../../../models/ItemArmor';
 import { listActiveHealthkitsByGameType } from '../../../../../models/ItemHealthKit';
 import { listActiveWeaponsByGameType } from '../../../../../models/ItemWeapon';
 import { GAME_TYPE, ITEM_TYPE, TRAIT } from '../../../../consts/global';
 import { hasLuck } from '../../../../utils';
+import {
+  generateItemRarityAvailability,
+  randomizeItems,
+  rarityWeight,
+  rollItemRarity,
+} from '../../../../utils/rollRarity';
 import {
   ARENA_HEALTHKITS,
   ARENA_PLAYER_PERFORMANCE,
@@ -15,12 +22,7 @@ import {
   SEARCH_WEAPONS_SUCCESS_RATE,
 } from '../../../consts';
 import { filterItemsByRarity, publishArenaMessage } from '../../../utils';
-import {
-  generateItemRarityAvailability,
-  randomizeItems,
-  rarityWeight,
-  rollItemRarity,
-} from '../../../../utils/rollRarity';
+
 import { arenaEngineReply } from './replies';
 
 export async function processSearchHealth(actions: ArenaRoundAction[], transaction: Transaction) {

--- a/src/games/arena/repositories/arena/engine/replies.ts
+++ b/src/games/arena/repositories/arena/engine/replies.ts
@@ -1,4 +1,4 @@
-import { ArenaPlayer, ArenaZone } from '../../../../../models';
+import type { ArenaPlayer, ArenaZone } from '../../../../../models';
 import {
   ARMOR_INVENTORY_EMOJI,
   BOSS_EMOJI,
@@ -16,14 +16,14 @@ import {
   SPINNER_EMOJI,
   WEAPON_INVENTORY_EMOJI,
 } from '../../../../consts/emojis';
-import { ITEM_RARITY, ArmorSpecs } from '../../../../consts/global';
+import type { ITEM_RARITY, ArmorSpecs } from '../../../../consts/global';
 import {
   basicHealthDisplayInParentheses,
   generateRarityColorEmoji,
   generateSoldierAnimationEmoji,
   randomSkinColor,
 } from '../../../../helpers';
-import { ARENA_PERK } from '../../../consts';
+import type { ARENA_PERK } from '../../../consts';
 import { arenaPerkStats } from '../../../utils';
 
 export function getCheerEmoji(player: ArenaPlayer) {

--- a/src/games/arena/repositories/arena/replies.ts
+++ b/src/games/arena/repositories/arena/replies.ts
@@ -37,8 +37,13 @@ import {
   randomSkinColor,
   zoneStatus,
 } from '../../../helpers';
-import { ARENA_HEALTHKITS, ChangeLocationParams } from '../../consts';
-import { ARENA_ACTIONS, ARENA_PLAYER_PERFORMANCE, MAX_PLAYER_HEALTH } from '../../consts';
+import type { ChangeLocationParams } from '../../consts';
+import {
+  ARENA_HEALTHKITS,
+  ARENA_ACTIONS,
+  ARENA_PLAYER_PERFORMANCE,
+  MAX_PLAYER_HEALTH,
+} from '../../consts';
 import { arenaNotifyEphemeral, arenaRoundActionMessageBuilder } from '../../utils';
 import { playerStatus } from '../../utils/playerStatus';
 

--- a/src/games/arena/repositories/zones/zone.ts
+++ b/src/games/arena/repositories/zones/zone.ts
@@ -1,15 +1,16 @@
-import { ArenaZone, User } from '../../../../models';
+import type { ArenaZone, User } from '../../../../models';
 import { findActiveArenaGame } from '../../../../models/ArenaGame';
+import type { ArenaZoneCreationAttributes } from '../../../../models/ArenaZone';
 import {
-  ArenaZoneCreationAttributes,
   createOrUpdateArenaZone,
   deactivateZones,
   deleteZoneById,
   findAllArenaZones,
   findArenaZoneById,
 } from '../../../../models/ArenaZone';
-import { ZoneData } from '../../../model/SlackDialogObject';
-import { adminAction, GameResponse, getGameError, getGameResponse } from '../../../utils';
+import type { ZoneData } from '../../../model/SlackDialogObject';
+import type { GameResponse } from '../../../utils';
+import { adminAction, getGameError, getGameResponse } from '../../../utils';
 import { ARENA_ZONE_RING } from '../../consts';
 import {
   generateArenaZoneModal,

--- a/src/games/arena/utils/addPlayer.ts
+++ b/src/games/arena/utils/addPlayer.ts
@@ -1,4 +1,5 @@
 import type { Transaction } from 'sequelize';
+
 import type { ArenaPlayer, User } from '../../../models';
 import { findActiveArenaGame } from '../../../models/ArenaGame';
 import { addArenaPlayers, addArenaPlayersToZones } from '../../../models/ArenaPlayer';

--- a/src/games/enemy/helpers/enemyPatterns.ts
+++ b/src/games/enemy/helpers/enemyPatterns.ts
@@ -1,5 +1,5 @@
-import { ARENA_ACTIONS_TYPE } from '../../../models/ArenaRoundAction';
-import { TOWER_ACTIONS_TYPE } from '../../../models/TowerRoundAction';
+import type { ARENA_ACTIONS_TYPE } from '../../../models/ArenaRoundAction';
+import type { TOWER_ACTIONS_TYPE } from '../../../models/TowerRoundAction';
 import { ARENA_ACTIONS, ARENA_ACTION_MAPPING } from '../../arena/consts';
 import { GAME_ACTION_MAPPING, GAME_TYPE, SHARED_ACTIONS } from '../../consts/global';
 import { TOWER_ACTIONS, TOWER_ACTION_MAPPING } from '../../tower/consts';

--- a/src/games/tower/actions/index.ts
+++ b/src/games/tower/actions/index.ts
@@ -1,18 +1,18 @@
 import { isNaN } from 'lodash';
+
 import { logger } from '../../../config';
-import { User } from '../../../models';
+import type { User } from '../../../models';
 import { getUserBySlackId } from '../../../models/User';
 import { gameResponseToSlackHandler } from '../../../modules/slack/utils';
 import { parseEscapedSlackId } from '../../../utils/slack';
 import { SAD_PARROT, SPINNER_EMOJI } from '../../consts/emojis';
 import { TEN, ZERO } from '../../consts/global';
-
 import { randomSkinColor } from '../../helpers';
 import type {
   SlackBlockKitButtonElement,
   SlackBlockKitSelectMenuElement,
 } from '../../model/SlackBlockKit';
-import { SlackBlockKitPayload } from '../../model/SlackBlockKitPayload';
+import type { SlackBlockKitPayload } from '../../model/SlackBlockKitPayload';
 import { getEphemeralText, getGameError, getGameResponse, slackRequest } from '../../utils';
 import { TOWER_SECONDARY_SLACK_ACTIONS, TOWER_SLACK_COMMANDS } from '../consts';
 import { TowerEngine } from '../repositories/tower/engine';
@@ -22,6 +22,7 @@ import {
   isTowerRaiderWithParamsAction,
   theTowerNotifyEphemeral,
 } from '../utils';
+
 import { towerConfigActionHandler } from './towerConfig';
 
 const theTower = new TowerRepository(TowerEngine.getInstance());

--- a/src/games/tower/actions/towerAction.ts
+++ b/src/games/tower/actions/towerAction.ts
@@ -1,12 +1,13 @@
-import { actionReply } from '.';
 import { logger } from '../../../config';
 import { getUserBySlackId } from '../../../models/User';
-import { SlackDialogSubmissionPayload, TowerFormData } from '../../model/SlackDialogObject';
+import type { SlackDialogSubmissionPayload, TowerFormData } from '../../model/SlackDialogObject';
 import { getGameError } from '../../utils';
 import { TOWER_SECONDARY_SLACK_ACTIONS } from '../consts';
 import { TowerEngine } from '../repositories/tower/engine';
 import { TowerRepository } from '../repositories/tower/tower';
 import { theTowerNotifyEphemeral } from '../utils';
+
+import { actionReply } from '.';
 
 const theTower = new TowerRepository(TowerEngine.getInstance());
 
@@ -51,19 +52,20 @@ export const handleTowerAction = async (payload: SlackDialogSubmissionPayload) =
       //     }
       //   });
       break;
-    case TOWER_SECONDARY_SLACK_ACTIONS.UPDATE_TOWER_ID:
-      theTower
-        .updateTowerBasicInfoForm(userRequesting, values as TowerFormData)
-        .then(async (response) => {
-          if (response?.type === 'error') {
-            await theTowerNotifyEphemeral(
-              response.text ?? 'Something went wrong',
-              userRequesting.slackId!,
-              userRequesting.slackId!
-            );
-          }
-        });
+    case TOWER_SECONDARY_SLACK_ACTIONS.UPDATE_TOWER_ID: {
+      const response = await theTower.updateTowerBasicInfoForm(
+        userRequesting,
+        values as TowerFormData
+      );
+      if (response?.type === 'error') {
+        await theTowerNotifyEphemeral(
+          response.text ?? 'Something went wrong',
+          userRequesting.slackId!,
+          userRequesting.slackId!
+        );
+      }
       break;
+    }
     default:
       logger.error(actionReply.somethingWentWrong);
       break;

--- a/src/games/tower/actions/towerConfig.ts
+++ b/src/games/tower/actions/towerConfig.ts
@@ -1,13 +1,14 @@
-import { actionReply } from '.';
 import { logger } from '../../../config';
-import { User } from '../../../models';
+import type { User } from '../../../models';
 import { gameResponseToSlackHandler } from '../../../modules/slack/utils';
 import { TEN, ZERO } from '../../consts/global';
-import { SlackBlockKitSelectMenuElement } from '../../model/SlackBlockKit';
+import type { SlackBlockKitSelectMenuElement } from '../../model/SlackBlockKit';
 import { extractSecondaryAction, getEphemeralText, getGameError, slackRequest } from '../../utils';
 import { TOWER_FLOOR_HIDING, TOWER_SECONDARY_SLACK_ACTIONS } from '../consts';
 import { TowerEngine } from '../repositories/tower/engine';
 import { TowerRepository } from '../repositories/tower/tower';
+
+import { actionReply } from '.';
 
 const theTower = new TowerRepository(TowerEngine.getInstance());
 

--- a/src/games/tower/actions/towerShortcut.ts
+++ b/src/games/tower/actions/towerShortcut.ts
@@ -1,9 +1,10 @@
-import { actionReply } from '.';
 import { logger } from '../../../config';
 import { getUserBySlackId } from '../../../models/User';
-import { SlackShortcutPayload } from '../../model/SlackShortcutPayload';
+import type { SlackShortcutPayload } from '../../model/SlackShortcutPayload';
 import { adminAction, getGameError } from '../../utils';
 import { theTowerNotifyEphemeral } from '../utils';
+
+import { actionReply } from '.';
 
 export async function handleTowerShortcut(payload: SlackShortcutPayload) {
   const {

--- a/src/games/tower/commands/index.ts
+++ b/src/games/tower/commands/index.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../config';
-import { User } from '../../../models';
+import type { User } from '../../../models';
 import { SPINNER_EMOJI } from '../../consts/emojis';
 import { getGameResponse } from '../../utils';
 import { TOWER_SLACK_COMMANDS } from '../consts';

--- a/src/games/tower/consts.ts
+++ b/src/games/tower/consts.ts
@@ -1,4 +1,4 @@
-import { TowerFloorBattlefieldEnemy, TowerRaider } from '../../models';
+import type { TowerFloorBattlefieldEnemy, TowerRaider } from '../../models';
 import { GAME_TYPE, SHARED_ACTIONS } from '../consts/global';
 import { generateEnemyPatterns } from '../enemy/helpers/enemyPatterns';
 

--- a/src/games/tower/generators/floors-and-enemies.ts
+++ b/src/games/tower/generators/floors-and-enemies.ts
@@ -1,7 +1,7 @@
-import { Enemy, TowerFloor } from '../../../models';
+import type { Enemy, TowerFloor } from '../../../models';
 import { FULL_HEALTH_HEART_EMOJI } from '../../consts/emojis';
 import { basicHealthDisplayInParentheses } from '../../helpers';
-import {
+import type {
   SlackBlockKitCompositionOption,
   SlackBlockKitLayoutElement,
 } from '../../model/SlackBlockKit';

--- a/src/games/tower/generators/gameplay.ts
+++ b/src/games/tower/generators/gameplay.ts
@@ -1,8 +1,8 @@
-import { Item, Perk, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../models';
+import type { Item, Perk, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../models';
 import { FULL_HEALTH_HEART_EMOJI, HEALTH_KIT_EMOJI } from '../../consts/emojis';
 import { ZERO } from '../../consts/global';
 import { generateRarityColorEmoji } from '../../helpers';
-import {
+import type {
   SlackBlockKitCompositionOption,
   SlackBlockKitLayoutElement,
 } from '../../model/SlackBlockKit';

--- a/src/games/tower/generators/info-setup-and-config.ts
+++ b/src/games/tower/generators/info-setup-and-config.ts
@@ -1,12 +1,13 @@
 import moment from 'moment';
-import { Game, TowerFloor } from '../../../models';
+
+import type { Game, TowerFloor } from '../../../models';
 import { FULL_HEALTH_HEART_EMOJI } from '../../consts/emojis';
-import {
+import type {
   SlackBlockKitDividerLayout,
   SlackBlockKitLayoutElement,
   SlackBlockKitSectionLayout,
 } from '../../model/SlackBlockKit';
-import { SlackDialog } from '../../model/SlackDialogObject';
+import type { SlackDialog } from '../../model/SlackDialogObject';
 import {
   blockKitButton,
   blockKitCompositionText,

--- a/src/games/tower/repositories/arena/zonesRepository.ts
+++ b/src/games/tower/repositories/arena/zonesRepository.ts
@@ -1,5 +1,5 @@
 import { createOrUpdateArenaZone, deleteZoneById } from '../../../../models/ArenaZone';
-import { ARENA_ZONE_RING } from '../../../arena/consts';
+import type { ARENA_ZONE_RING } from '../../../arena/consts';
 import { withZoneTransaction } from '../../../arena/utils';
 
 export interface IZoneEditorData {

--- a/src/games/tower/repositories/tower/actions/admin/tower-floors-operations.ts
+++ b/src/games/tower/repositories/tower/actions/admin/tower-floors-operations.ts
@@ -1,4 +1,5 @@
-import { Game, User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
+import { Game } from '../../../../../../models';
 import { findAllEnemies, findEnemyById } from '../../../../../../models/Enemy';
 import { findTowerFloorById } from '../../../../../../models/TowerFloor';
 import {
@@ -12,8 +13,9 @@ import {
 } from '../../../../../../models/TowerFloorEnemy';
 import { removeActionsByFloorBattlefieldEnemy } from '../../../../../../models/TowerRoundAction';
 import { TEN } from '../../../../../consts/global';
-import { SlackBlockKitLayoutElement } from '../../../../../model/SlackBlockKit';
-import { adminAction, GameResponse, getGameError, getGameResponse } from '../../../../../utils';
+import type { SlackBlockKitLayoutElement } from '../../../../../model/SlackBlockKit';
+import type { GameResponse } from '../../../../../utils';
+import { adminAction, getGameError, getGameResponse } from '../../../../../utils';
 import { TOWER_FLOOR_HIDING, TOWER_SECONDARY_SLACK_ACTIONS } from '../../../../consts';
 import {
   generateFloorEnemyAmountPickerBlock,

--- a/src/games/tower/repositories/tower/actions/admin/update-config-game.ts
+++ b/src/games/tower/repositories/tower/actions/admin/update-config-game.ts
@@ -1,6 +1,6 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findActiveTowerGame } from '../../../../../../models/TowerGame';
-import { TowerFormData } from '../../../../../model/SlackDialogObject';
+import type { TowerFormData } from '../../../../../model/SlackDialogObject';
 import { adminAction, getGameError, getGameResponse } from '../../../../../utils';
 import { generateUpdateTowerDialogView } from '../../../../generators/info-setup-and-config';
 import { theTowerNotifyEphemeral, theTowerOpenView, withTowerTransaction } from '../../../../utils';

--- a/src/games/tower/repositories/tower/actions/player/actions-menu.ts
+++ b/src/games/tower/repositories/tower/actions/player/actions-menu.ts
@@ -1,13 +1,11 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findTowerFloorById } from '../../../../../../models/TowerFloor';
 import { findEnemiesByFloorBattlefield } from '../../../../../../models/TowerFloorBattlefieldEnemy';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { generateTowerActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function raiderActions(userRequesting: User) {

--- a/src/games/tower/repositories/tower/actions/player/choose-perk-or-item.ts
+++ b/src/games/tower/repositories/tower/actions/player/choose-perk-or-item.ts
@@ -1,19 +1,17 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findArmorById } from '../../../../../../models/ItemArmor';
 import { findHealthkitById } from '../../../../../../models/ItemHealthKit';
 import { findWeaponById } from '../../../../../../models/ItemWeapon';
 import { findPerkById } from '../../../../../../models/Perk';
 import { addAmmoToItemInInventory } from '../../../../../../models/TowerItemInventory';
 import { ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { rarityWeight } from '../../../../../utils/rollRarity';
 import { MAX_RAIDER_HEALTH, TOWER_HEALTHKITS } from '../../../../consts';
 import { generateTowerActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function completeChoosePerkOrItem(

--- a/src/games/tower/repositories/tower/actions/player/enter.ts
+++ b/src/games/tower/repositories/tower/actions/player/enter.ts
@@ -1,4 +1,5 @@
-import { Game, User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
+import { Game } from '../../../../../../models';
 import { createBattlefield } from '../../../../../../models/TowerFloorBattlefield';
 import { addTowerFloorBattlefieldEnemies } from '../../../../../../models/TowerFloorBattlefieldEnemy';
 import {
@@ -8,7 +9,8 @@ import {
 import { startRound } from '../../../../../../models/TowerRound';
 import { findOrCreateTowerStatistics } from '../../../../../../models/TowerStatistics';
 import { ONE, ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { generateTowerActionsBlockKit } from '../../../../generators/gameplay';
 import {
   activeTowerHandler,

--- a/src/games/tower/repositories/tower/actions/player/exit.ts
+++ b/src/games/tower/repositories/tower/actions/player/exit.ts
@@ -1,7 +1,9 @@
-import { Game, User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
+import { Game } from '../../../../../../models';
 import { findRaiderByUser } from '../../../../../../models/TowerRaider';
 import { findActiveRound } from '../../../../../../models/TowerRound';
-import { GameResponse, getGameError, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameError, getGameResponse } from '../../../../../utils';
 import { activeTowerHandler, towerGatesHandler, withTowerTransaction } from '../../../../utils';
 import { leaveTower } from '../../../../utils/leave-tower';
 import { towerCommandReply } from '../../replies';

--- a/src/games/tower/repositories/tower/actions/player/hide.ts
+++ b/src/games/tower/repositories/tower/actions/player/hide.ts
@@ -1,17 +1,16 @@
 import type { Transaction } from 'sequelize';
-import { User } from '../../../../../../models';
+
+import type { User } from '../../../../../../models';
 import { setRoundAction } from '../../../../../../models/TowerRoundAction';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { TOWER_ACTIONS } from '../../../../consts';
 import {
   generateTowerActionsBlockKit,
   generateTowerStartRoundQuestionSection,
 } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function hideHelper(

--- a/src/games/tower/repositories/tower/actions/player/hunt.ts
+++ b/src/games/tower/repositories/tower/actions/player/hunt.ts
@@ -1,6 +1,8 @@
 import type { Transaction } from 'sequelize';
-import { Item, Trait, User } from '../../../../../../models';
-import { TowerAction } from '../../../../../../models/AvailableAction';
+
+import type { Item, User } from '../../../../../../models';
+import { Trait } from '../../../../../../models';
+import type { TowerAction } from '../../../../../../models/AvailableAction';
 import { findWeaponById } from '../../../../../../models/ItemWeapon';
 import {
   findEnemiesByFloorBattlefield,
@@ -9,7 +11,8 @@ import {
 } from '../../../../../../models/TowerFloorBattlefieldEnemy';
 import { findRoundAction, setRoundAction } from '../../../../../../models/TowerRoundAction';
 import { ONE, TRAIT, ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { generateGenericWeaponPickerBlock } from '../../../../../utils/generators/games';
 import { TOWER_ACTIONS, TOWER_SECONDARY_SLACK_ACTIONS } from '../../../../consts';
 import {
@@ -17,11 +20,8 @@ import {
   generateTowerStartRoundQuestionSection,
   generateTowerTargetEnemyPickerBlock,
 } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function chooseHuntTargetHelper(

--- a/src/games/tower/repositories/tower/actions/player/repeat-last-action.ts
+++ b/src/games/tower/repositories/tower/actions/player/repeat-last-action.ts
@@ -1,18 +1,17 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findWeaponById } from '../../../../../../models/ItemWeapon';
 import { findBattlefieldEnemyById } from '../../../../../../models/TowerFloorBattlefieldEnemy';
 import { findPreviousRound } from '../../../../../../models/TowerRound';
 import { findLastRaiderActionByRound } from '../../../../../../models/TowerRoundAction';
 import { TRAIT, ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { TOWER_ACTIONS } from '../../../../consts';
 import { generateTowerActionsBlockKit } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
+
 import { hideHelper } from './hide';
 import { chooseHuntTargetHelper, huntHelper } from './hunt';
 import { completeReviveHelper, reviveSelfHelper } from './revive';

--- a/src/games/tower/repositories/tower/actions/player/revive.ts
+++ b/src/games/tower/repositories/tower/actions/player/revive.ts
@@ -1,6 +1,7 @@
 import { random } from 'lodash';
 import type { Transaction } from 'sequelize';
-import { User } from '../../../../../../models';
+
+import type { User } from '../../../../../../models';
 import { findHealthkitByName } from '../../../../../../models/ItemHealthKit';
 import {
   findRaiderByUser,
@@ -8,18 +9,16 @@ import {
 } from '../../../../../../models/TowerRaider';
 import { setRoundAction } from '../../../../../../models/TowerRoundAction';
 import { ONE, ZERO } from '../../../../../consts/global';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { MAX_RAIDER_HEALTH, TOWER_ACTIONS, TOWER_HEALTHKITS } from '../../../../consts';
 import {
   generateTowerActionsBlockKit,
   generateTowerStartRoundQuestionSection,
   generateTowerTargetRaiderPickerBlock,
 } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function reviveSelfHelper(

--- a/src/games/tower/repositories/tower/actions/player/search.ts
+++ b/src/games/tower/repositories/tower/actions/player/search.ts
@@ -1,17 +1,17 @@
 import type { Transaction } from 'sequelize';
-import { User } from '../../../../../../models';
-import { setRoundAction, TOWER_ACTIONS_TYPE } from '../../../../../../models/TowerRoundAction';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+
+import type { User } from '../../../../../../models';
+import type { TOWER_ACTIONS_TYPE } from '../../../../../../models/TowerRoundAction';
+import { setRoundAction } from '../../../../../../models/TowerRoundAction';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { TOWER_ACTIONS } from '../../../../consts';
 import {
   generateTowerActionsBlockKit,
   generateTowerStartRoundQuestionSection,
 } from '../../../../generators/gameplay';
-import {
-  raiderActionsAlive,
-  TowerRaiderInteraction,
-  withTowerTransaction,
-} from '../../../../utils';
+import type { TowerRaiderInteraction } from '../../../../utils';
+import { raiderActionsAlive, withTowerTransaction } from '../../../../utils';
 import { towerCommandReply } from '../../replies';
 
 export async function searchForItemHelper(

--- a/src/games/tower/repositories/tower/actions/player/start-round.ts
+++ b/src/games/tower/repositories/tower/actions/player/start-round.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../../../../models';
+import type { User } from '../../../../../../models';
 import { findTowerFloorById } from '../../../../../../models/TowerFloor';
 import {
   createBattlefield,
@@ -14,20 +14,21 @@ import { startRound } from '../../../../../../models/TowerRound';
 import { findAllActionsByRound } from '../../../../../../models/TowerRoundAction';
 import { updateTowerAsCompleted } from '../../../../../../models/TowerStatistics';
 import { ONE, TWO, ZERO } from '../../../../../consts/global';
-import { SlackBlockKitLayoutElement } from '../../../../../model/SlackBlockKit';
-import { GameResponse, getGameResponse } from '../../../../../utils';
+import type { SlackBlockKitLayoutElement } from '../../../../../model/SlackBlockKit';
+import type { GameResponse } from '../../../../../utils';
+import { getGameResponse } from '../../../../../utils';
 import { MAX_RAIDER_HEALTH, TOWER_HEALTHKITS } from '../../../../consts';
 import {
   generateReEnterTowerQuestionSection,
   generateTowerActionsBlockKit,
   generateTowerPerkPickerSection,
 } from '../../../../generators/gameplay';
+import type { TowerRaiderInteraction } from '../../../../utils';
 import {
   publishTowerPublicMessage,
   raiderActionsAlive,
   theTowerNotifyEphemeral,
   theTowerNotifyInPrivate,
-  TowerRaiderInteraction,
   withTowerTransaction,
 } from '../../../../utils';
 import { leaveTower } from '../../../../utils/leave-tower';

--- a/src/games/tower/repositories/tower/enemyRepository.ts
+++ b/src/games/tower/repositories/tower/enemyRepository.ts
@@ -1,7 +1,7 @@
 import { createOrUpdateEnemy, deleteEnemyById } from '../../../../models/Enemy';
 import { createEnemyPattern, existsEnemyPattern } from '../../../../models/EnemyPattern';
 import { withEnemyTransaction } from '../../../arena/utils';
-import { AbilityProperty } from '../../../classes/GameAbilities';
+import type { AbilityProperty } from '../../../classes/GameAbilities';
 
 export interface IEnemyEditorData {
   id?: number;

--- a/src/games/tower/repositories/tower/engine/helpers/evaluate-hunt-enemies.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/evaluate-hunt-enemies.ts
@@ -1,12 +1,16 @@
 import { random } from 'lodash';
 import type { Transaction } from 'sequelize';
-import { Item, TowerFloorBattlefieldEnemy } from '../../../../../../models';
+
+import type { TowerFloorBattlefieldEnemy } from '../../../../../../models';
+import { Item } from '../../../../../../models';
 import { perkImpactCalculator } from '../../../../../../models/Perk';
 import { ONE, TRAIT, ZERO } from '../../../../../consts/global';
 import { hasLuck } from '../../../../../utils';
-import { HuntEnemyParams, HUNT_SUCCESS_RATE } from '../../../../consts';
+import type { HuntEnemyParams } from '../../../../consts';
+import { HUNT_SUCCESS_RATE } from '../../../../consts';
 import { theTowerNotifyInPrivate } from '../../../../utils';
 import { towerEngineReply } from '../replies';
+
 import { evaluateInitiative } from './evaluate-initiative';
 import { damageSpecsGenerator } from './generate-damage-specs';
 import { targetsPicker } from './target-picker';

--- a/src/games/tower/repositories/tower/engine/helpers/evaluate-hunt-raiders.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/evaluate-hunt-raiders.ts
@@ -1,12 +1,15 @@
 import { random } from 'lodash';
 import type { Transaction } from 'sequelize';
-import { TowerRaider } from '../../../../../../models';
+
+import type { TowerRaider } from '../../../../../../models';
 import { perkImpactCalculator } from '../../../../../../models/Perk';
 import { ONE, TRAIT, ZERO } from '../../../../../consts/global';
 import { hasLuck } from '../../../../../utils';
-import { ENEMY_HUNT_SUCCESS_RATE, HuntPlayerParams } from '../../../../consts';
+import type { HuntPlayerParams } from '../../../../consts';
+import { ENEMY_HUNT_SUCCESS_RATE } from '../../../../consts';
 import { theTowerNotifyInPrivate } from '../../../../utils';
 import { towerEngineReply } from '../replies';
+
 import { evaluateInitiative } from './evaluate-initiative';
 import { damageSpecsGenerator } from './generate-damage-specs';
 import { targetsPicker } from './target-picker';

--- a/src/games/tower/repositories/tower/engine/helpers/evaluate-initiative.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/evaluate-initiative.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from 'sequelize';
-import {
+
+import type {
   Item,
   TowerFloorBattlefieldEnemy,
   TowerItemInventory,

--- a/src/games/tower/repositories/tower/engine/helpers/generate-damage-specs.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/generate-damage-specs.ts
@@ -1,7 +1,8 @@
-import { TowerFloorBattlefieldEnemy, TowerRaider } from '../../../../../../models';
+import type { TowerFloorBattlefieldEnemy, TowerRaider } from '../../../../../../models';
 import { perkImpactCalculator } from '../../../../../../models/Perk';
-import { AbilityProperty } from '../../../../../classes/GameAbilities';
-import { DamageDealtSpecs, ZERO } from '../../../../../consts/global';
+import type { AbilityProperty } from '../../../../../classes/GameAbilities';
+import type { DamageDealtSpecs } from '../../../../../consts/global';
+import { ZERO } from '../../../../../consts/global';
 import { damageIncrease, damageReduction, nonLessThanZeroParam } from '../../../../../utils';
 import { roundTwoDecimalPlaces } from '../../../../../utils/math';
 

--- a/src/games/tower/repositories/tower/engine/helpers/generate-enemies-actions.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/generate-enemies-actions.ts
@@ -1,9 +1,12 @@
 import type { Transaction } from 'sequelize';
-import { TowerFloorBattlefieldEnemy, TowerRound } from '../../../../../../models';
-import { setRoundAction, TOWER_ACTIONS_TYPE } from '../../../../../../models/TowerRoundAction';
-import { GAME_ACTION_MAPPING } from '../../../../../consts/global';
+
+import type { TowerFloorBattlefieldEnemy, TowerRound } from '../../../../../../models';
+import type { TOWER_ACTIONS_TYPE } from '../../../../../../models/TowerRoundAction';
+import { setRoundAction } from '../../../../../../models/TowerRoundAction';
+import type { GAME_ACTION_MAPPING } from '../../../../../consts/global';
 import { parseSymbolToEnemyAction } from '../../../../../enemy/helpers/enemyPatterns';
-import { TOWER_ACTIONS, TOWER_ACTION_MAPPING } from '../../../../consts';
+import type { TOWER_ACTION_MAPPING } from '../../../../consts';
+import { TOWER_ACTIONS } from '../../../../consts';
 import { rollEnemyAction } from '../../../../utils';
 
 export async function generateEnemiesActions(

--- a/src/games/tower/repositories/tower/engine/helpers/generate-loot.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/generate-loot.ts
@@ -1,6 +1,7 @@
 import { random } from 'lodash';
-import { Transaction } from 'sequelize/types';
-import { Item, TowerFloor, TowerRaider } from '../../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { Item, TowerFloor, TowerRaider } from '../../../../../../models';
 import { listActiveArmorsByGameType } from '../../../../../../models/ItemArmor';
 import { listActiveHealthkitsByGameType } from '../../../../../../models/ItemHealthKit';
 import { listActiveWeaponsByGameType } from '../../../../../../models/ItemWeapon';

--- a/src/games/tower/repositories/tower/engine/helpers/generate-perks-and-items.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/generate-perks-and-items.ts
@@ -1,6 +1,7 @@
 import { random, sampleSize } from 'lodash';
-import { Transaction } from 'sequelize/types';
-import { Item, TowerFloor, TowerRaider } from '../../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { Item, TowerFloor, TowerRaider } from '../../../../../../models';
 import { listActiveArmorsByGameType } from '../../../../../../models/ItemArmor';
 import { listActiveHealthkitsByGameType } from '../../../../../../models/ItemHealthKit';
 import { listActiveWeaponsByGameType } from '../../../../../../models/ItemWeapon';

--- a/src/games/tower/repositories/tower/engine/helpers/target-picker.ts
+++ b/src/games/tower/repositories/tower/engine/helpers/target-picker.ts
@@ -1,5 +1,6 @@
 import { sampleSize } from 'lodash';
-import { Item, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../../../../models';
+
+import type { Item, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../../../../models';
 import { ONE, TRAIT, TWO, ZERO } from '../../../../../consts/global';
 
 type HuntableEntity = TowerFloorBattlefieldEnemy | TowerRaider;

--- a/src/games/tower/repositories/tower/engine/index.ts
+++ b/src/games/tower/repositories/tower/engine/index.ts
@@ -1,8 +1,10 @@
 import type { Transaction } from 'sequelize';
-import { TowerRound, TowerRoundAction } from '../../../../../models';
+
+import type { TowerRound, TowerRoundAction } from '../../../../../models';
 import { findRaidersByFloorBattlefield } from '../../../../../models/TowerRaider';
 import { TOWER_ACTIONS } from '../../../consts';
 import { filterActionsById } from '../../../utils';
+
 import { awardPrize } from './helpers/award-prize';
 import { generateEnemiesActions } from './helpers/generate-enemies-actions';
 import { generateLoot } from './helpers/generate-loot';

--- a/src/games/tower/repositories/tower/engine/processCharge.ts
+++ b/src/games/tower/repositories/tower/engine/processCharge.ts
@@ -1,6 +1,8 @@
-import { Transaction } from 'sequelize/types';
-import { TowerRaider, TowerRoundAction } from '../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { TowerRaider, TowerRoundAction } from '../../../../../models';
 import { theTowerNotifyInPrivate } from '../../../utils';
+
 import { towerEngineReply } from './replies';
 
 export async function processCharge(

--- a/src/games/tower/repositories/tower/engine/processHealOrRevive.ts
+++ b/src/games/tower/repositories/tower/engine/processHealOrRevive.ts
@@ -1,11 +1,13 @@
-import { Transaction } from 'sequelize/types';
-import { TowerRound, TowerRoundAction } from '../../../../../models';
+import type { Transaction } from 'sequelize/types';
+
+import type { TowerRound, TowerRoundAction } from '../../../../../models';
 import { findHealthkitByName } from '../../../../../models/ItemHealthKit';
 import { perkImpactCalculator } from '../../../../../models/Perk';
 import { findRaiderById } from '../../../../../models/TowerRaider';
 import { ZERO } from '../../../../consts/global';
 import { MAX_RAIDER_HEALTH, TOWER_HEALTHKITS } from '../../../consts';
 import { theTowerNotifyInPrivate } from '../../../utils';
+
 import { towerEngineReply } from './replies';
 
 export async function processHealOrRevive(

--- a/src/games/tower/repositories/tower/engine/processHide.ts
+++ b/src/games/tower/repositories/tower/engine/processHide.ts
@@ -1,6 +1,8 @@
 import type { Transaction } from 'sequelize';
-import { TowerRaider, TowerRoundAction } from '../../../../../models';
+
+import type { TowerRaider, TowerRoundAction } from '../../../../../models';
 import { theTowerNotifyInPrivate } from '../../../utils';
+
 import { towerEngineReply } from './replies';
 
 export async function processHide(

--- a/src/games/tower/repositories/tower/engine/processHunt.ts
+++ b/src/games/tower/repositories/tower/engine/processHunt.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from 'sequelize';
-import { TowerRaider, TowerRound, TowerRoundAction } from '../../../../../models';
+
+import type { TowerRaider, TowerRound, TowerRoundAction } from '../../../../../models';
 import { findWeaponById } from '../../../../../models/ItemWeapon';
 import { perkImpactCalculator } from '../../../../../models/Perk';
 import { findEnemiesByFloorBattlefield } from '../../../../../models/TowerFloorBattlefieldEnemy';
@@ -9,6 +10,7 @@ import { TRAIT } from '../../../../consts/global';
 import { hasLuck } from '../../../../utils';
 import { LOSE_ACTION_RATE } from '../../../consts';
 import { initiativeSort, theTowerNotifyInPrivate } from '../../../utils';
+
 import { huntEnemies } from './helpers/evaluate-hunt-enemies';
 import { huntRaiders } from './helpers/evaluate-hunt-raiders';
 import { towerEngineReply } from './replies';

--- a/src/games/tower/repositories/tower/engine/replies.ts
+++ b/src/games/tower/repositories/tower/engine/replies.ts
@@ -13,7 +13,7 @@ import {
   SPINNER_EMOJI,
   WEAPON_INVENTORY_EMOJI,
 } from '../../../../consts/emojis';
-import { DamageDealtSpecs, ITEM_RARITY } from '../../../../consts/global';
+import type { DamageDealtSpecs, ITEM_RARITY } from '../../../../consts/global';
 import {
   basicHealthDisplayInParentheses,
   generateRarityColorEmoji,

--- a/src/games/tower/repositories/tower/replies.ts
+++ b/src/games/tower/repositories/tower/replies.ts
@@ -1,5 +1,6 @@
 import { capitalize } from 'lodash';
-import {
+
+import type {
   Enemy,
   Game,
   Item,
@@ -8,7 +9,7 @@ import {
   TowerRaider,
   TowerStatistics,
 } from '../../../../models';
-import { TOWER_ACTIONS_TYPE } from '../../../../models/TowerRoundAction';
+import type { TOWER_ACTIONS_TYPE } from '../../../../models/TowerRoundAction';
 import {
   APPROVE_SIGN,
   FREE_AGENT_EMOJI,

--- a/src/games/tower/repositories/tower/tower.ts
+++ b/src/games/tower/repositories/tower/tower.ts
@@ -1,7 +1,8 @@
-import { User } from '../../../../models';
-import { TowerFormData } from '../../../model/SlackDialogObject';
-import { GameResponse } from '../../../utils';
-import { TOWER_FLOOR_HIDING } from '../../consts';
+import type { User } from '../../../../models';
+import type { TowerFormData } from '../../../model/SlackDialogObject';
+import type { GameResponse } from '../../../utils';
+import type { TOWER_FLOOR_HIDING } from '../../consts';
+
 import {
   askEndGame,
   cancelEndGame,

--- a/src/games/tower/repositories/tower/towerRepository.ts
+++ b/src/games/tower/repositories/tower/towerRepository.ts
@@ -1,6 +1,7 @@
 import { startTowerGame } from '../../../../models/TowerGame';
 import { findAdmin } from '../../../../models/User';
 import { withTowerTransaction } from '../../utils';
+
 import { endGame, openOrCloseTowerGates } from './actions/admin/create-or-finish-game';
 
 export interface ICreateTowerGameData {

--- a/src/games/tower/utils/index.ts
+++ b/src/games/tower/utils/index.ts
@@ -1,31 +1,20 @@
 import { random } from 'lodash';
 import type { Transaction } from 'sequelize';
+
 import { getConfig } from '../../../config';
-import { Game, TowerRaider, TowerRound, TowerRoundAction, User } from '../../../models';
+import type { TowerRound, TowerRoundAction, User } from '../../../models';
+import { Game, TowerRaider } from '../../../models';
 import { findActiveTowerGame } from '../../../models/TowerGame';
 import { findRaiderByUser } from '../../../models/TowerRaider';
 import { findActiveRound } from '../../../models/TowerRound';
-import { TOWER_ACTIONS_TYPE } from '../../../models/TowerRoundAction';
-import { TOWER_HEALTHKITS, TOWER_REPOSITORY_NAME } from '../../tower/consts';
-
+import type { TOWER_ACTIONS_TYPE } from '../../../models/TowerRoundAction';
 import { ONE, HUNDRED, ITEM_RARITY, ZERO } from '../../consts/global';
-import { roundActionMessageBuilder, RoundActionMessageBuilderParams } from '../../helpers';
+import type { RoundActionMessageBuilderParams } from '../../helpers';
+import { roundActionMessageBuilder } from '../../helpers';
 import type { SlackBlockKitLayoutElement } from '../../model/SlackBlockKit';
 import {
-  chatUnfurl,
-  GameResponse,
-  getGameError,
-  hasLuck,
-  notifyEphemeral,
-  notifyInPrivate,
-  openView,
-  slackRequest,
-  withTransaction,
-} from '../../utils';
-import { GameError } from '../../utils/GameError';
-import { RollSearchRarityParams, weightedChance } from '../../utils/rollRarity';
-
-import {
+  TOWER_HEALTHKITS,
+  TOWER_REPOSITORY_NAME,
   LUCK_ELIXIR_BOOST,
   TOWER_ACTIONS,
   LOOT_PRIZE_HEALTH_KIT_CHANCE,
@@ -38,7 +27,21 @@ import {
   ENEMY_HIDE_CHANCE,
   ENEMY_HUNT_CHANCE,
   TOWER_LOOT_PRIZES,
-} from '../consts';
+} from '../../tower/consts';
+import type { GameResponse } from '../../utils';
+import {
+  chatUnfurl,
+  getGameError,
+  hasLuck,
+  notifyEphemeral,
+  notifyInPrivate,
+  openView,
+  slackRequest,
+  withTransaction,
+} from '../../utils';
+import { GameError } from '../../utils/GameError';
+import type { RollSearchRarityParams } from '../../utils/rollRarity';
+import { weightedChance } from '../../utils/rollRarity';
 import { towerCommandReply } from '../repositories/tower/replies';
 
 const TOWER_SLACK_CHANNEL = 'SLACK_THE_TOWER_CHANNEL';

--- a/src/games/tower/utils/leave-tower.ts
+++ b/src/games/tower/utils/leave-tower.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from 'sequelize';
-import { TowerRaider, TowerRound } from '../../../models';
+
+import type { TowerRaider, TowerRound } from '../../../models';
 import { Ability } from '../../classes/GameAbilities';
 
 export async function leaveTower(

--- a/src/games/tower/utils/raiderStatus.ts
+++ b/src/games/tower/utils/raiderStatus.ts
@@ -1,4 +1,4 @@
-import { TowerFloor, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../models';
+import type { TowerFloor, TowerFloorBattlefieldEnemy, TowerRaider } from '../../../models';
 import { PLAYER_HIDE_EMOJI, PLAYER_VISIBLE_EMOJI } from '../../consts/emojis';
 import { ZERO } from '../../consts/global';
 import {

--- a/src/games/utils/generators/games.ts
+++ b/src/games/utils/generators/games.ts
@@ -1,9 +1,9 @@
-import { ArenaItemInventory, Item, TowerItemInventory } from '../../../models';
+import type { ArenaItemInventory, Item, TowerItemInventory } from '../../../models';
 import type { ARENA_SECONDARY_ACTIONS } from '../../arena/consts';
 import { INFINITY_GIF_EMOJI } from '../../consts/emojis';
 import { generateRarityColorEmoji } from '../../helpers';
-import { SlackBlockKitCompositionOption } from '../../model/SlackBlockKit';
-import { TOWER_SECONDARY_SLACK_ACTIONS } from '../../tower/consts';
+import type { SlackBlockKitCompositionOption } from '../../model/SlackBlockKit';
+import type { TOWER_SECONDARY_SLACK_ACTIONS } from '../../tower/consts';
 
 import {
   blockKitAction,
@@ -15,7 +15,7 @@ import {
 } from './slack';
 
 export function generateEndGameConfirmationBlockKit(
-  questionText: string = 'Are you *absolutely sure* you want to *end the game*?',
+  questionText = 'Are you *absolutely sure* you want to *end the game*?',
   confirmActionValue: ARENA_SECONDARY_ACTIONS | TOWER_SECONDARY_SLACK_ACTIONS,
   cancelActionValue: ARENA_SECONDARY_ACTIONS | TOWER_SECONDARY_SLACK_ACTIONS
 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,10 @@
 import 'source-map-support/register';
-import dotenv from 'dotenv';
-
 import { getConfig, logger } from './config';
-
-if (getConfig('NODE_ENV') !== 'production') {
-  dotenv.config({ path: '.env.dev' });
-}
-
 import { SEED_MODE } from './consts/api';
 import { initDb, sequelize } from './db';
 import { getServerWithPlugins } from './server';
 
-(async () => {
+void (async () => {
   // DB Setup
   await initDb();
 

--- a/src/migrations/20220524172835-create-Session-table.ts
+++ b/src/migrations/20220524172835-create-Session-table.ts
@@ -1,4 +1,5 @@
-import { DataTypes, QueryInterface, Sequelize } from 'sequelize';
+import type { QueryInterface, Sequelize } from 'sequelize';
+import { DataTypes } from 'sequelize';
 
 interface SequelizeContext {
   context: {

--- a/src/models/AchievementUnlocked.ts
+++ b/src/models/AchievementUnlocked.ts
@@ -1,4 +1,4 @@
-import { Association, Transaction } from 'sequelize';
+import type { Association, Transaction } from 'sequelize';
 import {
   Table,
   Column,
@@ -14,6 +14,7 @@ import {
 } from 'sequelize-typescript';
 
 import { ZERO } from '../games/consts/global';
+
 import { User, Achievement } from './';
 
 interface AchievementUnlockedAttributes {

--- a/src/models/ArenaRoundAction.ts
+++ b/src/models/ArenaRoundAction.ts
@@ -13,9 +13,9 @@ import {
 import type { ARENA_ACTIONS } from '../games/arena/consts';
 
 import { ArenaAction } from './AvailableAction';
+import { Item } from './Item';
 
 import { AvailableAction, ArenaPlayer, ArenaRound } from './';
-import { Item } from './Item';
 
 type Values<T> = T[keyof T];
 

--- a/src/models/Enemy.ts
+++ b/src/models/Enemy.ts
@@ -15,10 +15,10 @@ import {
   AutoIncrement,
   AllowNull,
 } from 'sequelize-typescript';
-import { EnemyPattern, EnemyTrait, Organization, Trait } from '.';
+
 import { logger } from '../config';
 import { Ability, AbilityProperty } from '../games/classes/GameAbilities';
-import { TRAIT } from '../games/consts/global';
+import type { TRAIT } from '../games/consts/global';
 import {
   BOSS_MAX_DAMAGE_RATE,
   BOSS_MIN_DAMAGE_RATE,
@@ -29,6 +29,8 @@ import {
   MIN_BOSS_HEALTH,
   MIN_ENEMY_HEALTH,
 } from '../games/tower/consts';
+
+import { EnemyPattern, EnemyTrait, Organization, Trait } from '.';
 
 export interface EnemyCreationAttributes {
   id?: number;

--- a/src/models/EnemyTrait.ts
+++ b/src/models/EnemyTrait.ts
@@ -1,8 +1,9 @@
 import { Table, Column, Model, DataType, ForeignKey, BelongsTo } from 'sequelize-typescript';
-import { Association } from 'sequelize/types';
+import type { Association } from 'sequelize/types';
+
+import { TRAIT } from '../games/consts/global';
 
 import { Enemy, Trait } from '.';
-import { TRAIT } from '../games/consts/global';
 
 interface EnemyTraitAttributes {
   _enemyId: number;

--- a/src/models/Perk.ts
+++ b/src/models/Perk.ts
@@ -10,15 +10,19 @@ import {
   PrimaryKey,
   AllowNull,
 } from 'sequelize-typescript';
+
 import { Ability, AbilityProperty } from '../games/classes/GameAbilities';
+import type { PerkMultiplierKey } from '../games/consts/global';
 import {
   ITEM_RARITY,
-  PerkMultiplierKey,
   PERK_CONDITIONS,
   PERK_MULTIPLIERS,
+  PERK,
+  PERK_ARCHETYPE,
 } from '../games/consts/global';
-import { PERK, PERK_ARCHETYPE } from '../games/consts/global';
-import { ItemRarity, Organization, TowerRaider } from '.';
+
+import type { TowerRaider } from '.';
+import { ItemRarity, Organization } from '.';
 
 interface PerkAttributes {
   id: PERK;

--- a/src/models/PerkInventory.ts
+++ b/src/models/PerkInventory.ts
@@ -12,8 +12,9 @@ import {
   AutoIncrement,
 } from 'sequelize-typescript';
 
-import { Perk, TowerRaider, TowerFloorBattlefieldEnemy } from '.';
 import { ONE, PERK } from '../games/consts/global';
+
+import { Perk, TowerRaider, TowerFloorBattlefieldEnemy } from '.';
 
 interface PerkInventoryAttributes {
   id: number;

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,5 +1,4 @@
-import { v4 as uuid4 } from 'uuid';
-import { Association, Transaction } from 'sequelize';
+import type { Association, Transaction } from 'sequelize';
 import {
   Table,
   Column,
@@ -15,11 +14,13 @@ import {
   UpdatedAt,
   Unique,
 } from 'sequelize-typescript';
+import { v4 as uuid4 } from 'uuid';
 
-import { ZERO } from '../games/consts/global';
-import { User } from './';
-import { MILLISECONDS_IN_A_MONTH } from '../consts/api';
 import { logger } from '../config';
+import { MILLISECONDS_IN_A_MONTH } from '../consts/api';
+import { ZERO } from '../games/consts/global';
+
+import { User } from './';
 
 interface SessionAttributes {
   id: number;
@@ -150,7 +151,7 @@ export function createSession(
 
 export function updateSession(
   sessionData: SessionUpdateAttributes,
-  updateToken: boolean = true,
+  updateToken = true,
   transaction?: Transaction
 ) {
   const token = uuid4();

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -17,6 +17,7 @@ import {
 
 import { USER_ROLE_NAME } from '../consts/model';
 import { isScopeRole } from '../utils/permissions';
+
 import { Organization } from './Organization';
 
 interface TeamAttributes {

--- a/src/models/TowerFloorBattlefield.ts
+++ b/src/models/TowerFloorBattlefield.ts
@@ -11,8 +11,9 @@ import {
   AutoIncrement,
 } from 'sequelize-typescript';
 
-import { TowerRaider, TowerRound, TowerFloor, TowerFloorBattlefieldEnemy } from '.';
 import { ONE, ZERO } from '../games/consts/global';
+
+import { TowerRaider, TowerRound, TowerFloor, TowerFloorBattlefieldEnemy } from '.';
 
 interface TowerFloorBattlefieldAttributes {
   id: number;

--- a/src/models/TowerFloorBattlefieldEnemy.ts
+++ b/src/models/TowerFloorBattlefieldEnemy.ts
@@ -13,11 +13,15 @@ import {
   PrimaryKey,
 } from 'sequelize-typescript';
 
-import { TowerFloorEnemy, TowerFloorBattlefield, Perk, PerkInventory } from '.';
-import { Ability, AbilityProperty, AbilityPropertyKeys } from '../games/classes/GameAbilities';
-import { ONE, TRAIT, ZERO } from '../games/consts/global';
+import type { AbilityPropertyKeys } from '../games/classes/GameAbilities';
+import { Ability, AbilityProperty } from '../games/classes/GameAbilities';
+import type { TRAIT } from '../games/consts/global';
+import { ONE, ZERO } from '../games/consts/global';
 import { INITIATIVE_DECREASE, INITIATIVE_INCREASE } from '../games/tower/consts';
+
 import { Enemy } from './Enemy';
+
+import { TowerFloorEnemy, TowerFloorBattlefield, Perk, PerkInventory } from '.';
 
 interface TowerFloorBattlefieldEnemyAttributes {
   id: number;

--- a/src/models/TowerItemInventory.ts
+++ b/src/models/TowerItemInventory.ts
@@ -10,8 +10,9 @@ import {
   AutoIncrement,
 } from 'sequelize-typescript';
 
-import { Item, TowerRaider } from '.';
 import { ZERO } from '../games/consts/global';
+
+import { Item, TowerRaider } from '.';
 
 interface TowerItemInventoryAttributes {
   id: number;

--- a/src/models/TowerRaider.ts
+++ b/src/models/TowerRaider.ts
@@ -14,13 +14,10 @@ import {
   PrimaryKey,
 } from 'sequelize-typescript';
 
-import { listActiveWeaponsByGameType } from './ItemWeapon';
-import { perkImpactCalculator } from './Perk';
-import { setPerkInventoryQuantity } from './PerkInventory';
-import { Item, User, TowerFloorBattlefield, TowerItemInventory, Perk, PerkInventory } from '.';
-import { GAME_TYPE, ITEM_TYPE, ONE, PERK, TRAIT, ZERO } from '../games/consts/global';
-import { Ability, AbilityProperty, AbilityPropertyKeys } from '../games/classes/GameAbilities';
-import { addAmmoToItemInInventory, getRaiderItemCount } from './TowerItemInventory';
+import type { AbilityPropertyKeys } from '../games/classes/GameAbilities';
+import { Ability, AbilityProperty } from '../games/classes/GameAbilities';
+import type { PERK } from '../games/consts/global';
+import { GAME_TYPE, ITEM_TYPE, ONE, TRAIT, ZERO } from '../games/consts/global';
 import {
   INITIATIVE_DECREASE,
   INITIATIVE_INCREASE,
@@ -28,6 +25,13 @@ import {
   MAX_AMOUNT_HEALTHKITS_ALLOWED,
   MAX_RAIDER_HEALTH,
 } from '../games/tower/consts';
+
+import { listActiveWeaponsByGameType } from './ItemWeapon';
+import { perkImpactCalculator } from './Perk';
+import { setPerkInventoryQuantity } from './PerkInventory';
+import { addAmmoToItemInInventory, getRaiderItemCount } from './TowerItemInventory';
+
+import { Item, User, TowerFloorBattlefield, TowerItemInventory, Perk, PerkInventory } from '.';
 
 interface TowerRaiderAttributes {
   id: number;

--- a/src/models/TowerRound.ts
+++ b/src/models/TowerRound.ts
@@ -12,6 +12,8 @@ import {
   PrimaryKey,
 } from 'sequelize-typescript';
 
+import { ITEM_TYPE } from '../games/consts/global';
+
 import {
   TowerRoundAction,
   TowerRaider,
@@ -21,7 +23,6 @@ import {
   TowerFloorBattlefield,
   TowerFloorBattlefieldEnemy,
 } from '.';
-import { ITEM_TYPE } from '../games/consts/global';
 
 interface TowerRoundAttributes {
   id: number;

--- a/src/models/TowerStatistics.ts
+++ b/src/models/TowerStatistics.ts
@@ -9,8 +9,9 @@ import {
   PrimaryKey,
 } from 'sequelize-typescript';
 
-import { User, TowerGame } from '.';
 import { ONE, ZERO } from '../games/consts/global';
+
+import { User, TowerGame } from '.';
 
 interface TowerStatisticsAttributes {
   attempts: number;

--- a/src/modules/slack/slackHandlers.ts
+++ b/src/modules/slack/slackHandlers.ts
@@ -5,9 +5,9 @@ import { random } from 'lodash';
 import { SLACK_COMMAND_LOCAL_PREFIX, SLACK_COMMAND_STAGING_PREFIX } from '../../consts/api';
 import { handleArenaAction, handleViewSubmissionAction } from '../../games/arena/actions';
 import { HUNDRED, ZERO } from '../../games/consts/global';
-import { SlackChallengesPayload } from '../../games/model/SlackChallengePayload';
-import { SlackChatUnfurlUrl } from '../../games/model/SlackChatUnfurlPayload';
-import { SlackEventsPayload } from '../../games/model/SlackEventPayload';
+import type { SlackChallengesPayload } from '../../games/model/SlackChallengePayload';
+import type { SlackChatUnfurlUrl } from '../../games/model/SlackChatUnfurlPayload';
+import type { SlackEventsPayload } from '../../games/model/SlackEventPayload';
 import type { SlackSlashCommandPayload } from '../../games/model/SlackSlashCommandPayload';
 import { handleTowerBlockAction } from '../../games/tower/actions';
 import { handleTowerAction } from '../../games/tower/actions/towerAction';
@@ -63,8 +63,9 @@ export const towerSlackActionHandler: Lifecycle.Method = async (request, _h) => 
   const slackActionPayload = request.pre.slackActionPayload;
   try {
     switch (slackActionPayload.type) {
-      case 'shortcut':
-      // return handleTowerShortcut(slackActionPayload as SlackShortcutPayload);
+      // case 'shortcut':
+      // // return handleTowerShortcut(slackActionPayload as SlackShortcutPayload);
+      //   break
       case 'view_submission':
         return handleTowerAction(slackActionPayload);
       case 'block_actions':

--- a/src/modules/slack/slackHandlers.ts
+++ b/src/modules/slack/slackHandlers.ts
@@ -63,9 +63,8 @@ export const towerSlackActionHandler: Lifecycle.Method = async (request, _h) => 
   const slackActionPayload = request.pre.slackActionPayload;
   try {
     switch (slackActionPayload.type) {
-      // case 'shortcut':
+      case 'shortcut':
       // // return handleTowerShortcut(slackActionPayload as SlackShortcutPayload);
-      //   break
       case 'view_submission':
         return handleTowerAction(slackActionPayload);
       case 'block_actions':

--- a/src/modules/slack/utils.ts
+++ b/src/modules/slack/utils.ts
@@ -9,31 +9,30 @@ import { getConfig, logger } from '../../config';
 import { arenaSwitchCommand } from '../../games/arena/commands';
 import { isArenaCommand } from '../../games/arena/utils';
 import { SAD_PARROT } from '../../games/consts/emojis';
+import { gamesSwitchCommand } from '../../games/general/commands';
 import { slackActionsPayloadSchema } from '../../games/model/SlackActionPayload';
 import type { SlackActionsPayload } from '../../games/model/SlackActionPayload';
 import { slackBlockPayloadSchema } from '../../games/model/SlackBlockKit';
 import type { SlackBlockKitPayload } from '../../games/model/SlackBlockKitPayload';
-import {
-  SlackChallengesPayload,
-  slackChallengesPayloadSchema,
-} from '../../games/model/SlackChallengePayload';
+import type { SlackChallengesPayload } from '../../games/model/SlackChallengePayload';
+import { slackChallengesPayloadSchema } from '../../games/model/SlackChallengePayload';
 import type { SlackDialogSubmissionPayload } from '../../games/model/SlackDialogObject';
 import { slackSSDialogSubmissionPayloadSchema } from '../../games/model/SlackDialogObject';
 import type { SlackDialogsPayload } from '../../games/model/SlackDialogPayload';
 import { slackDialogsPayloadSchema } from '../../games/model/SlackDialogPayload';
-import { SlackEventsPayload, slackEventsPayloadSchema } from '../../games/model/SlackEventPayload';
+import type { SlackEventsPayload } from '../../games/model/SlackEventPayload';
+import { slackEventsPayloadSchema } from '../../games/model/SlackEventPayload';
 import type { SlackShortcutPayload } from '../../games/model/SlackShortcutPayload';
 import { slackSShortcutPayloadSchema } from '../../games/model/SlackShortcutPayload';
 import type { SlackSlashCommandPayload } from '../../games/model/SlackSlashCommandPayload';
 import { slackSlashCommandPayloadSchema } from '../../games/model/SlackSlashCommandPayload';
+import { towerSwitchCommand } from '../../games/tower/commands';
+import { isGamesHQCommand, isTowerCommand } from '../../games/tower/utils';
 import type { GameResponse } from '../../games/utils';
 import { getEphemeralBlock, getEphemeralText } from '../../games/utils';
 import { getUserBySlackId } from '../../models/User';
 import type { SlackConfigKey } from '../../utils/cryptography';
 import { validateWebhookSignatures } from '../../utils/cryptography';
-import { isGamesHQCommand, isTowerCommand } from '../../games/tower/utils';
-import { towerSwitchCommand } from '../../games/tower/commands';
-import { gamesSwitchCommand } from '../../games/general/commands';
 
 export const isRequestFresh = (timestamp: number, freshMinutes?: number): boolean => {
   const SIXTY_SECONDS = 60;

--- a/src/plugins/firebasePlugin.ts
+++ b/src/plugins/firebasePlugin.ts
@@ -1,11 +1,21 @@
+import type { App } from 'firebase-admin/app';
 import { initializeApp, applicationDefault } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 
-initializeApp({
-  credential: applicationDefault(),
-});
+// eslint-disable-next-line functional/no-let
+let firebaseApp: App | undefined;
+
+const initApp = () => {
+  if (!firebaseApp) {
+    firebaseApp = initializeApp({
+      credential: applicationDefault(),
+    });
+  }
+};
 
 export const createUserInFirebase = async (email: string, displayName: string) => {
+  initApp();
+
   try {
     const firebaseUser = await getAuth().getUserByEmail(email);
     return firebaseUser;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,11 +1,11 @@
 import type { ServerRoute } from '@hapi/hapi';
 
-import { slackArenaRoutes } from './modules/slack/slackArenaRoute';
-import { slackRoutes } from './modules/slack/slackRoutes';
 import { adminRoutes } from './modules/dashboard/adminRoutes';
-import { slackTowerRoutes } from './modules/slack/slackTowerRoute';
 import { gameDevRoutes } from './modules/gameDevs/gameDevRoutes';
 import { gameDevWebhookRoutes } from './modules/gameDevs/gameDevWebhooksRoutes';
+import { slackArenaRoutes } from './modules/slack/slackArenaRoute';
+import { slackRoutes } from './modules/slack/slackRoutes';
+import { slackTowerRoutes } from './modules/slack/slackTowerRoute';
 import { userRoutes } from './modules/users/userRoutes';
 
 export const routes: ServerRoute[] = [

--- a/src/seeders/20210712154520-initial-db-seeds.ts
+++ b/src/seeders/20210712154520-initial-db-seeds.ts
@@ -1,6 +1,7 @@
 import { isNumber } from 'lodash';
 import type { QueryInterface, Sequelize, Transaction } from 'sequelize';
 import { Op, QueryTypes } from 'sequelize';
+
 import { generateSecret } from '../utils/cryptography';
 
 enum AVAILABLE_ACTION {

--- a/src/seeders/20210804135226-the-arena-seeds.ts
+++ b/src/seeders/20210804135226-the-arena-seeds.ts
@@ -1,5 +1,5 @@
-import { QueryInterface, QueryOptions, QueryTypes, Sequelize, Transaction } from 'sequelize';
-import { Op } from 'sequelize';
+import type { QueryInterface, QueryOptions, Sequelize, Transaction } from 'sequelize';
+import { QueryTypes, Op } from 'sequelize';
 
 enum ARENA_ZONE_RING {
   ONE_A = '1A',

--- a/src/seeders/20210915200432-the-tower-seeds.ts
+++ b/src/seeders/20210915200432-the-tower-seeds.ts
@@ -1,4 +1,5 @@
-import { QueryInterface, QueryTypes, Sequelize, Transaction } from 'sequelize';
+import type { QueryInterface, Sequelize, Transaction } from 'sequelize';
+import { QueryTypes } from 'sequelize';
 
 enum GAME_TYPE {
   TOWER = 'The Tower',

--- a/test/api-utils/webhookValidation.test.ts
+++ b/test/api-utils/webhookValidation.test.ts
@@ -1,0 +1,202 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { Request } from '@hapi/hapi';
+import { webhookValidation } from '../../src/api-utils/webhookValidations';
+import * as GameType from '../../src/models/GameType';
+import { fail } from 'assert';
+import { signMessage } from '../../src/utils/cryptography';
+
+describe('webhookValidations', async () => {
+  it('should return gameType on successful validation with payload', async () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        test: 'this is my payload',
+      })
+    );
+
+    const gameSigningSecret = '123455';
+    const gameClientSignature = 'myClientSignature';
+    const timestamp = new Date().getTime();
+    const signatureMessage = `v0:${timestamp}:${payload}`;
+
+    const stubbedFindFameByClientSecret = sinon
+      .stub(GameType, 'findGameTypeByClientSecret')
+      .resolves({
+        name: 'fakeGame',
+        signingSecret: gameSigningSecret,
+      } as any);
+
+    const request = {
+      headers: {
+        'xtu-request-timestamp': timestamp,
+        'xtu-signature': `v0=${signMessage(signatureMessage, gameSigningSecret)}`,
+        'xtu-client-secret': gameClientSignature,
+      },
+      payload,
+    } as unknown as Request;
+
+    const rslt = await webhookValidation(request, {} as any);
+
+    expect(stubbedFindFameByClientSecret).to.be.calledOnce;
+    expect(rslt.gameType).to.deep.equal({
+      name: 'fakeGame',
+      signingSecret: gameSigningSecret,
+    });
+  });
+
+  it('should return gameType on successful validation without payload', async () => {
+    const gameSigningSecret = '123455';
+    const gameClientSignature = 'myClientSignature';
+    const timestamp = new Date().getTime();
+    const signatureMessage = `v0:${timestamp}:${JSON.stringify({})}`;
+
+    const stubbedFindFameByClientSecret = sinon
+      .stub(GameType, 'findGameTypeByClientSecret')
+      .resolves({
+        name: 'fakeGame',
+        signingSecret: gameSigningSecret,
+      } as any);
+
+    const request = {
+      headers: {
+        'xtu-request-timestamp': timestamp,
+        'xtu-signature': `v0=${signMessage(signatureMessage, gameSigningSecret)}`,
+        'xtu-client-secret': gameClientSignature,
+      },
+    } as unknown as Request;
+
+    const rslt = await webhookValidation(request, {} as any);
+
+    expect(stubbedFindFameByClientSecret).to.be.calledOnce;
+    expect(rslt.gameType).to.deep.equal({
+      name: 'fakeGame',
+      signingSecret: gameSigningSecret,
+    });
+  });
+
+  it('should throw error if payload is not Buffer', async () => {
+    const gameSigningSecret = '123455';
+    const gameClientSignature = 'myClientSignature';
+    const timestamp = new Date().getTime();
+    const signatureMessage = `v0:${timestamp}:${JSON.stringify({})}`;
+
+    sinon.stub(GameType, 'findGameTypeByClientSecret').resolves({
+      name: 'fakeGame',
+      signingSecret: gameSigningSecret,
+    } as any);
+
+    const payload = {
+      test: 'this is my payload not as Buffer',
+    };
+
+    const request = {
+      headers: {
+        'xtu-request-timestamp': timestamp,
+        'xtu-signature': `v0=${signMessage(signatureMessage, gameSigningSecret)}`,
+        'xtu-client-secret': gameClientSignature,
+      },
+      payload,
+    } as unknown as Request;
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(e.message).to.equal('Payload is not a Buffer');
+    }
+  });
+
+  it('should throw error if invalid timestamp in xtu-request-timestamp header', async () => {
+    const request = {
+      headers: {
+        'xtu-request-timestamp': 'invalid',
+      },
+    } as unknown as Request;
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(e.message).to.equal('Invalid timestamp');
+    }
+  });
+
+  it('should throw error if timestamp in xtu-request-timestamp is not a fresh request', async () => {
+    const request = {
+      headers: {
+        'xtu-request-timestamp': new Date().getTime() / 1000 - 1000000,
+      },
+    } as unknown as Request;
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(e.message).to.equal('Invalid timestamp');
+    }
+  });
+
+  it('should throw error if gametype does not exists', async () => {
+    const request = {
+      headers: {
+        'xtu-request-timestamp': new Date().getTime(),
+      },
+    } as unknown as Request;
+
+    sinon.stub(GameType, 'findGameTypeByClientSecret').resolves(null);
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(e.message).to.equal('Game not found!');
+    }
+  });
+
+  it('should throw error if gametype signingSecret is undefined', async () => {
+    const request = {
+      headers: {
+        'xtu-request-timestamp': new Date().getTime(),
+      },
+    } as unknown as Request;
+
+    sinon.stub(GameType, 'findGameTypeByClientSecret').resolves({
+      signingSecret: '',
+    } as any);
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(e.message).to.equal('APP SIGNING SECRET not acceptable');
+    }
+  });
+
+  it('should throw error if webhook signature is invalid', async () => {
+    const gameSigningSecret = '123455';
+    const gameClientSignature = 'myClientSignature';
+    const signatureMessage = 'invalid';
+
+    const stubbedFindFameByClientSecret = sinon
+      .stub(GameType, 'findGameTypeByClientSecret')
+      .resolves({
+        signingSecret: gameSigningSecret,
+      } as any);
+
+    const request = {
+      headers: {
+        'xtu-request-timestamp': new Date().getTime(),
+        'xtu-signature': `v0=${signMessage(signatureMessage, gameSigningSecret)}`,
+        'xtu-client-secret': gameClientSignature,
+      },
+    } as unknown as Request;
+
+    try {
+      await webhookValidation(request, {} as any);
+      fail('call should throw error on test');
+    } catch (e: any) {
+      expect(stubbedFindFameByClientSecret).to.be.calledWith(gameClientSignature);
+      expect(e.message).to.equal('Invalid signature');
+    }
+  });
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -9,7 +9,6 @@ import Boom from '@hapi/boom';
 import Joi from 'joi';
 import { User } from '../src/models';
 import { USER_ROLE_LEVEL } from '../src/consts/model';
-
 declare module 'mocha' {
   interface Suite {
     gameshqDontClearDBAfterEach?: boolean;
@@ -89,7 +88,6 @@ before(async function () {
   if (!isIntegration(this)) {
     return;
   }
-
   await initDb();
   // await sequelize.sync({ match: /_test$/, logging: false });
 


### PR DESCRIPTION

made some adjustments. now we can rely on calling the npm run test . it will run the unit and integration tests and eslint calls without errors. This could be a considered a step forward into adding tests checks in the ci/cd
- fixed some tsc and eslint errors
- added some tests

