### PR TITLE
🪄 [XHQ-4387] Add acknowledgeSlackResponse to Slack methods

### DIFF
--- a/src/models/TowerRoundAction.ts
+++ b/src/models/TowerRoundAction.ts
@@ -258,7 +258,7 @@ export async function findRoundAction(
   { raiderId = null, enemyId = null, roundId }: RoundActionKey,
   transaction?: Transaction
 ) {
-  let mutableWhereQuery: OptionalWhereParams = {
+  const mutableWhereQuery: OptionalWhereParams = {
     _towerRoundId: roundId,
   };
   if (raiderId) {

--- a/src/models/TowerStatistics.ts
+++ b/src/models/TowerStatistics.ts
@@ -11,7 +11,8 @@ import {
 
 import { ONE, ZERO } from '../games/consts/global';
 
-import { User, TowerGame, Perk, PerkInventory } from '.';
+import type { Perk, PerkInventory } from '.';
+import { User, TowerGame } from '.';
 
 interface TowerStatisticsAttributes {
   attempts: number;

--- a/src/modules/slack/slackHandlers.ts
+++ b/src/modules/slack/slackHandlers.ts
@@ -13,6 +13,7 @@ import { handleTowerBlockAction } from '../../games/tower/actions';
 import { handleTowerAction } from '../../games/tower/actions/towerAction';
 import { theTowerUnfurlLink } from '../../games/tower/utils';
 import { blockKitCompositionImage } from '../../games/utils/generators/slack';
+import { acknowledgeSlackResponse } from '../../utils/slack';
 
 import { slackCommandSwitcher } from './utils';
 
@@ -25,6 +26,10 @@ export const testRouteHandler: Lifecycle.Method = async () => {
 };
 
 export const slackCommandHandler: Lifecycle.Method = async (request, _h) => {
+  // We need to respond to Slack within 3000ms or the action will fail.
+  // So we acknowledge the request and then handle the command asynchronously.
+  void acknowledgeSlackResponse();
+
   const slashCommandPayload: SlackSlashCommandPayload = request.pre.slashCommandPayload;
   slashCommandPayload.command = slashCommandPayload.command?.replace(
     SLACK_COMMAND_STAGING_PREFIX,
@@ -44,6 +49,10 @@ export const slackCommandHandler: Lifecycle.Method = async (request, _h) => {
 };
 
 export const arenaSlackActionHandler: Lifecycle.Method = async (request, _h) => {
+  // We need to respond to Slack within 3000ms or the action will fail.
+  // So we acknowledge the request and then handle the command asynchronously.
+  void acknowledgeSlackResponse();
+
   const slackActionPayload = request.pre.slackActionPayload;
 
   try {
@@ -60,6 +69,10 @@ export const arenaSlackActionHandler: Lifecycle.Method = async (request, _h) => 
 };
 
 export const towerSlackActionHandler: Lifecycle.Method = async (request, _h) => {
+  // We need to respond to Slack within 3000ms or the action will fail.
+  // So we acknowledge the request and then handle the command asynchronously.
+  void acknowledgeSlackResponse();
+
   const slackActionPayload = request.pre.slackActionPayload;
   try {
     switch (slackActionPayload.type) {

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -33,3 +33,10 @@ export function parseEscapedSlackId(slackUser: string) {
     return slackUser.replace('@', '');
   }
 }
+
+// We need to acknowledge the request to Slack within 3 seconds
+export function acknowledgeSlackResponse() {
+  process.nextTick(() => {
+    return {};
+  });
+}


### PR DESCRIPTION
### Ticket

https://x-team-internal.atlassian.net/browse/XHQ-4387?atlOrigin=eyJpIjoiZmVhMTYzOTIzZjgzNDg5ZGI3YmFiOWI2MzhlZjRiMWUiLCJwIjoiaiJ9

### Description

Add `acknowledgeSlackResponse` to acknowledge the Slack request as soon as possible to avoid Timeout errors. (Some of the endpoints and queries take longer than 3 seconds and we need to acknowledge before that and continue with the rest of the process in the background)

### Screenshots

N/A